### PR TITLE
Fix build by adding next-pwa type declarations

### DIFF
--- a/next-pwa.d.ts
+++ b/next-pwa.d.ts
@@ -1,0 +1,19 @@
+declare module "next-pwa" {
+  import type { NextConfig } from "next";
+
+  interface PWAOptions {
+    dest?: string;
+    disable?: boolean;
+    register?: boolean;
+    scope?: string;
+    sw?: string;
+    runtimeCaching?: unknown;
+    buildExcludes?: unknown;
+    [key: string]: unknown;
+  }
+
+  type WithPWA = (options?: PWAOptions) => (nextConfig: NextConfig) => NextConfig;
+
+  const withPWA: WithPWA;
+  export default withPWA;
+}


### PR DESCRIPTION
## Summary
- add a TypeScript declaration for the next-pwa module so the Next.js build can resolve its types
- describe the basic PWA configuration options and export signature used in next.config.ts

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4dfcc4f0c8325b7294e6f3f6bb882