### PR TITLE
Add LP subdomain experience with responsive green-themed design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,20 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #fbfdfa;
+  --foreground: #0f2f1f;
+  --ryokufuu-50: #f2fbf7;
+  --ryokufuu-100: #e1f6ec;
+  --ryokufuu-200: #c7ecd9;
+  --ryokufuu-300: #9bdac0;
+  --ryokufuu-400: #5bbf9a;
+  --ryokufuu-500: #2f8f74;
+  --ryokufuu-600: #257961;
+  --ryokufuu-700: #1f5f4c;
+  --ryokufuu-800: #1a4c3d;
+  --ryokufuu-900: #143a2f;
+  --surface-soft: rgba(47, 143, 116, 0.08);
+  --surface-strong: rgba(47, 143, 116, 0.15);
 }
 
 @theme inline {
@@ -14,8 +26,10 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #081711;
+    --foreground: #edf7f2;
+    --surface-soft: rgba(160, 235, 209, 0.08);
+    --surface-strong: rgba(160, 235, 209, 0.18);
   }
 }
 
@@ -23,4 +37,12 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+section {
+  scroll-margin-top: 80px;
+}
+
+a {
+  color: inherit;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Dummy LINE UI Starter",
-  description: "Progressive web starter for LINE inspired experiences.",
+  title: "LINE風PWAダミー環境 | PWA LINE Studio",
+  description:
+    "完全オフラインで使えるLINE風PWAダミー環境。トークや友だちを自由に編集し、安全に研修・検証ができる法人向けツール。",
   manifest: "/manifest.json",
   icons: {
     icon: "/favicon.ico",
@@ -28,7 +29,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[color:var(--background)] text-[color:var(--foreground)]`}
+      >
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/lp/_components/automation-flow.tsx
+++ b/app/lp/_components/automation-flow.tsx
@@ -1,0 +1,52 @@
+const flows = [
+  {
+    title: "TXTインポートで即時生成",
+    description:
+      "LINEアプリから書き出したTXTをアップロードすると、友だち・トーク・VOOMを自動構築。研修の準備時間を大幅短縮します。",
+  },
+  {
+    title: "ドラッグ&ドロップ編集",
+    description:
+      "トークの並び替えやメッセージの追加・削除を直感的に操作。オフラインでも即座に結果を反映できます。",
+  },
+  {
+    title: "履歴ロールバック",
+    description:
+      "研修ごとにスナップショットを作成し、ワンクリックで状態を復元。誤操作があっても安心です。",
+  },
+];
+
+export function AutomationFlow() {
+  return (
+    <section className="px-6 py-20 sm:px-10">
+      <div className="mx-auto max-w-6xl space-y-12">
+        <div className="text-center">
+          <h2 className="text-3xl font-semibold text-[color:var(--ryokufuu-800)] sm:text-4xl">
+            LP申込で手に入る自動化ワークフロー
+          </h2>
+          <p className="mx-auto mt-4 max-w-3xl text-base leading-relaxed text-[color:var(--ryokufuu-700)]">
+            LPから申し込むことで、ダミー環境へのアクセスと同時に、シナリオ生成・編集・共有を効率化する専用ワークフローが利用可能になります。
+          </p>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {flows.map((flow, index) => (
+            <div
+              key={flow.title}
+              className="flex flex-col gap-4 rounded-3xl bg-gradient-to-br from-[color:var(--ryokufuu-50)] via-white to-[color:var(--ryokufuu-100)] p-8 shadow-lg shadow-[rgba(23,53,40,0.08)]"
+            >
+              <div className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-[color:var(--surface-soft)] text-[color:var(--ryokufuu-600)]">
+                <span className="text-lg font-semibold">{index + 1}</span>
+              </div>
+              <h3 className="text-xl font-semibold text-[color:var(--ryokufuu-800)]">
+                {flow.title}
+              </h3>
+              <p className="text-sm leading-relaxed text-[color:var(--ryokufuu-700)]">
+                {flow.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/lp/_components/cta-footer.tsx
+++ b/app/lp/_components/cta-footer.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export function CtaFooter() {
+  return (
+    <section className="px-6 pb-20 sm:px-10">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 rounded-[3rem] bg-gradient-to-br from-[color:var(--ryokufuu-900)] via-[color:var(--ryokufuu-700)] to-[color:var(--ryokufuu-500)] px-10 py-12 text-white shadow-2xl">
+        <div className="space-y-4 text-center">
+          <h2 className="text-3xl font-semibold sm:text-4xl">
+            LPから申し込んで、安全な仮想チャット空間へ
+          </h2>
+          <p className="text-base leading-relaxed text-white/85">
+            実LINEの見た目・操作感を忠実に再現したPWA環境で、研修やデモをもっとスムーズに。LP限定の特典で今日から使い始めましょう。
+          </p>
+        </div>
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <Link
+            href="https://example.com/signup"
+            className="rounded-full bg-white px-10 py-3 text-base font-semibold text-[color:var(--ryokufuu-700)] shadow-lg shadow-[rgba(8,23,17,0.25)] transition hover:bg-[color:var(--ryokufuu-50)]"
+          >
+            無料トライアルを申し込む
+          </Link>
+          <Link
+            href="mailto:support@example.com"
+            className="text-base font-semibold text-white underline-offset-4 hover:underline"
+          >
+            導入の相談をする
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/lp/_components/experience-preview.tsx
+++ b/app/lp/_components/experience-preview.tsx
@@ -1,0 +1,72 @@
+export function ExperiencePreview() {
+  return (
+    <section className="px-6 sm:px-10">
+      <div className="mx-auto flex max-w-6xl flex-col gap-10 rounded-[3rem] bg-white/80 p-10 shadow-2xl shadow-[rgba(23,53,40,0.12)] ring-1 ring-[color:var(--surface-strong)] lg:flex-row">
+        <div className="flex-1 space-y-6">
+          <h2 className="text-3xl font-semibold text-[color:var(--ryokufuu-800)] sm:text-4xl">
+            スマホとデスクトップの両方で直感的
+          </h2>
+          <p className="text-base leading-relaxed text-[color:var(--ryokufuu-700)]">
+            LPから申し込み後、端末に合わせた最適UIを即時提供。スマホではタブバーのスワイプやフッターナビゲーションを再現。デスクトップでは横幅を活かした会話リスト＋トークビューの2ペイン表示に対応しています。
+          </p>
+          <ul className="space-y-4 text-sm text-[color:var(--ryokufuu-700)]">
+            <li className="flex items-start gap-3">
+              <span className="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-[color:var(--ryokufuu-500)]" />
+              スマホではフルスクリーンのPWA体験。ホーム画面アイコンから起動してアプリと同等の操作性。
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-[color:var(--ryokufuu-500)]" />
+              デスクトップではリサイズに応じたレスポンシブ。チームでの画面共有やオンライン研修にも最適。
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-[color:var(--ryokufuu-500)]" />
+              完全オフラインのため、機密情報を扱うトレーニングやデモも安全に実施できます。
+            </li>
+          </ul>
+        </div>
+        <div className="flex flex-1 flex-col gap-6 lg:flex-row lg:items-center lg:justify-end">
+          <div className="relative mx-auto w-full max-w-[16rem] rounded-[2.5rem] bg-gradient-to-b from-[color:var(--ryokufuu-100)] to-[color:var(--ryokufuu-200)] p-5 shadow-xl">
+            <div className="absolute inset-x-10 top-3 h-1 rounded-full bg-[color:var(--ryokufuu-300)]" />
+            <div className="mt-10 space-y-4 rounded-2xl bg-white/90 p-4 text-xs text-[color:var(--ryokufuu-800)] shadow-lg">
+              <div className="space-y-1">
+                <p className="font-semibold text-[color:var(--ryokufuu-600)]">トークルーム</p>
+                <p>ダミーの会話をタップで編集・削除。オフラインで履歴管理。</p>
+              </div>
+              <div className="rounded-xl bg-[color:var(--surface-soft)] p-3">
+                <p className="font-semibold text-[color:var(--ryokufuu-600)]">友だち</p>
+                <p className="mt-1 text-[color:var(--ryokufuu-800)]">
+                  タグを付与して研修シナリオを整理。
+                </p>
+              </div>
+              <div className="space-y-1">
+                <p className="font-semibold text-[color:var(--ryokufuu-600)]">VOOM・ニュース</p>
+                <p>配信イメージを切り替えながら確認できます。</p>
+              </div>
+            </div>
+          </div>
+          <div className="relative mx-auto w-full max-w-[22rem] rounded-3xl border border-[color:var(--surface-strong)] bg-white/90 p-6 shadow-xl">
+            <div className="space-y-4 text-sm text-[color:var(--ryokufuu-800)]">
+              <div className="flex items-center justify-between border-b border-[color:var(--surface-soft)] pb-3">
+                <p className="font-semibold text-[color:var(--ryokufuu-700)]">デスクトップビュー</p>
+                <span className="rounded-full bg-[color:var(--surface-soft)] px-3 py-1 text-xs text-[color:var(--ryokufuu-600)]">
+                  Web
+                </span>
+              </div>
+              <p>
+                会話リストとチャット画面を左右に並べた2ペイン。URLバーの表示を最小化し、アプリライクなモードで研修できます。
+              </p>
+              <div className="rounded-2xl bg-[color:var(--surface-soft)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[color:var(--ryokufuu-600)]">
+                  LP SPECIAL
+                </p>
+                <p className="mt-2 text-sm">
+                  LP申込者限定でテンプレートセットと研修シナリオガイドを無償提供。すぐに使い始められます。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/lp/_components/faq-section.tsx
+++ b/app/lp/_components/faq-section.tsx
@@ -1,0 +1,44 @@
+const faqs = [
+  {
+    question: "実際のLINEアカウントと同期されますか？",
+    answer:
+      "同期は行いません。ダミー環境内で完結し、送受信を伴う通信は将来的な手動バックアップ時のみ発生します。",
+  },
+  {
+    question: "スマホとPCで機能差はありますか？",
+    answer:
+      "機能差はなく、レイアウトのみ最適化されます。スマホではPWAとしてインストールし、PCではブラウザ上で2ペイン表示が可能です。",
+  },
+  {
+    question: "契約を終了するとデータはどうなりますか？",
+    answer:
+      "契約停止時にはローカルに保存されたデータも自動ロックされ、閲覧できなくなります。再契約時に復元も可能です。",
+  },
+];
+
+export function FaqSection() {
+  return (
+    <section className="px-6 pb-20 sm:px-10">
+      <div className="mx-auto max-w-4xl space-y-10 rounded-[3rem] bg-white/90 p-10 shadow-2xl shadow-[rgba(23,53,40,0.12)] ring-1 ring-[color:var(--surface-soft)]">
+        <div className="text-center">
+          <h2 className="text-3xl font-semibold text-[color:var(--ryokufuu-800)]">よくある質問</h2>
+          <p className="mt-2 text-sm text-[color:var(--ryokufuu-700)]">
+            不明点はサポートチームが24時間以内に回答いたします。LP経由のチャットサポートもご利用ください。
+          </p>
+        </div>
+        <div className="space-y-6">
+          {faqs.map((faq) => (
+            <div key={faq.question} className="rounded-2xl bg-[color:var(--surface-soft)] p-6">
+              <p className="text-lg font-semibold text-[color:var(--ryokufuu-700)]">
+                Q. {faq.question}
+              </p>
+              <p className="mt-3 text-sm leading-relaxed text-[color:var(--ryokufuu-800)]">
+                {faq.answer}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/lp/_components/hero-section.tsx
+++ b/app/lp/_components/hero-section.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+
+export function HeroSection() {
+  return (
+    <header className="relative isolate overflow-hidden bg-gradient-to-br from-[color:var(--ryokufuu-900)] via-[color:var(--ryokufuu-700)] to-[color:var(--ryokufuu-500)] px-6 pb-20 pt-24 text-white sm:px-10 sm:pb-28 sm:pt-28">
+      <div className="mx-auto flex max-w-6xl flex-col gap-14 text-center">
+        <div className="space-y-6">
+          <span className="inline-flex items-center justify-center gap-2 self-center rounded-full bg-white/15 px-5 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-white/80 backdrop-blur">
+            LP限定プラン
+          </span>
+          <h1 className="text-4xl font-semibold leading-tight text-balance sm:text-6xl">
+            スマホにもPCにも馴染むLINE風PWA。\n研修・検証をまるごとLPから申し込み。
+          </h1>
+          <p className="mx-auto max-w-3xl text-base leading-relaxed text-white/85 sm:text-lg">
+            実LINEそっくりのUIと操作感を備えたダミー環境をPWAで提供。スマートフォンではホーム画面のアプリアイコンから、デスクトップではブラウザで。通信を伴わない安全なチャット検証を実現します。
+          </p>
+        </div>
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-5">
+          <Link
+            href="#trial"
+            className="rounded-full bg-white px-9 py-3 text-base font-semibold text-[color:var(--ryokufuu-800)] shadow-lg shadow-[rgba(15,47,31,0.2)] transition hover:bg-[color:var(--ryokufuu-50)]"
+          >
+            7日間無料トライアルを申し込む
+          </Link>
+          <Link
+            href="#features"
+            className="rounded-full border border-white/40 px-9 py-3 text-base font-semibold text-white transition hover:border-white hover:bg-white/10"
+          >
+            機能を詳しく見る
+          </Link>
+        </div>
+        <div className="grid gap-6 rounded-3xl bg-white/10 p-8 text-left shadow-lg shadow-[rgba(8,23,17,0.3)] backdrop-blur sm:grid-cols-3">
+          {[
+            {
+              title: "オフライン完結",
+              description:
+                "通信は将来的な手動バックアップ時のみ。契約停止時はローカルデータもロックして、情報の持ち出しを防ぎます。",
+            },
+            {
+              title: "TXTアップロードで自動生成",
+              description:
+                "実LINEから書き出したTXTを読み込むだけでトーク・友だち・VOOMを復元。研修シナリオ作成を数分で完了。",
+            },
+            {
+              title: "PWAとして配布",
+              description:
+                "ホーム画面に追加してURLバーのないアプリ表示に。スマホ・タブレット・デスクトップに同一UIを展開できます。",
+            },
+          ].map((item) => (
+            <div key={item.title} className="space-y-3">
+              <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+              <p className="text-sm leading-relaxed text-white/80">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="pointer-events-none absolute -top-24 right-10 h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.35),transparent)]" />
+      <div className="pointer-events-none absolute bottom-[-6rem] left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.2),transparent)]" />
+    </header>
+  );
+}

--- a/app/lp/_components/pricing-section.tsx
+++ b/app/lp/_components/pricing-section.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+
+export function PricingSection() {
+  return (
+    <section id="trial" className="px-6 py-20 sm:px-10">
+      <div className="mx-auto max-w-5xl space-y-10 text-center">
+        <div className="space-y-4">
+          <h2 className="text-3xl font-semibold text-[color:var(--ryokufuu-800)] sm:text-4xl">
+            シンプルな定額プラン
+          </h2>
+          <p className="text-base text-[color:var(--ryokufuu-700)]">
+            月額480円でLINE風PWAダミー環境を無制限に利用可能。LP限定で7日間の無料トライアルをご用意しました。
+          </p>
+        </div>
+        <div className="grid gap-6 rounded-[3rem] bg-white/90 p-10 shadow-2xl shadow-[rgba(23,53,40,0.12)] ring-1 ring-[color:var(--surface-strong)] md:grid-cols-2">
+          <div className="flex flex-col items-center gap-3">
+            <p className="text-sm font-semibold uppercase tracking-[0.35em] text-[color:var(--ryokufuu-500)]">
+              LP Exclusive
+            </p>
+            <p className="text-5xl font-semibold text-[color:var(--ryokufuu-800)]">
+              480<span className="text-2xl font-medium">円/月</span>
+            </p>
+            <p className="text-sm text-[color:var(--ryokufuu-700)]">
+              端末台数無制限 / 契約期間中のデータ暗号化
+            </p>
+          </div>
+          <ul className="space-y-3 text-left text-sm text-[color:var(--ryokufuu-700)]">
+            {[
+              "PWAとしてスマホ・タブレット・PCに配布",
+              "TXTアップロードによる自動データ生成",
+              "友だち・トーク・VOOM・ニュース・ウォレットのフルタブ構成",
+              "将来的な手動バックアップ機能 (通信時のみ接続)",
+              "契約停止時のローカルデータロック",
+            ].map((benefit) => (
+              <li key={benefit} className="flex items-start gap-2">
+                <span className="mt-1 inline-flex h-2 w-2 rounded-full bg-[color:var(--ryokufuu-500)]" />
+                {benefit}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex flex-col items-center gap-3">
+          <Link
+            href="https://example.com/signup"
+            className="inline-flex items-center justify-center rounded-full bg-[color:var(--ryokufuu-600)] px-10 py-3 text-base font-semibold text-white shadow-lg shadow-[rgba(47,143,116,0.35)] transition hover:bg-[color:var(--ryokufuu-700)]"
+          >
+            今すぐ申し込む
+          </Link>
+          <p className="text-xs text-[color:var(--ryokufuu-700)]">
+            7日以内のキャンセルで料金は発生しません。
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/lp/_components/value-highlights.tsx
+++ b/app/lp/_components/value-highlights.tsx
@@ -1,0 +1,54 @@
+interface ValueHighlight {
+  title: string;
+  description: string;
+  caption: string;
+}
+
+interface ValueHighlightsProps {
+  values: ValueHighlight[];
+}
+
+export function ValueHighlights({ values }: ValueHighlightsProps) {
+  return (
+    <section
+      id="features"
+      className="px-6 py-16 sm:px-10 sm:py-20"
+      aria-labelledby="lp-value-heading"
+    >
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 lg:flex-row">
+        <div className="lg:max-w-sm">
+          <h2
+            id="lp-value-heading"
+            className="text-3xl font-semibold text-[color:var(--ryokufuu-800)] sm:text-4xl"
+          >
+            タブも体験導線も、LINEさながらの操作感
+          </h2>
+          <p className="mt-4 text-base leading-relaxed text-[color:var(--ryokufuu-700)]">
+            友だち・トーク・VOOM・ニュース・ウォレットを搭載し、LP経由で申し込み後すぐに本番さながらの操作を再現。端末に合わせて最適化されたレイアウトで、スマホ・PCどちらの検証もスムーズです。
+          </p>
+        </div>
+        <div className="grid flex-1 gap-6 sm:grid-cols-2">
+          {values.map((value) => (
+            <article
+              key={value.title}
+              className="group relative overflow-hidden rounded-3xl bg-white/80 p-6 shadow-lg shadow-[rgba(23,53,40,0.08)] ring-1 ring-[color:var(--surface-soft)] transition hover:-translate-y-1 hover:shadow-xl"
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-[rgba(47,143,116,0.1)] opacity-0 transition group-hover:opacity-100" />
+              <div className="relative space-y-3">
+                <span className="inline-flex rounded-full bg-[color:var(--surface-soft)] px-3 py-1 text-xs font-semibold text-[color:var(--ryokufuu-600)]">
+                  {value.caption}
+                </span>
+                <h3 className="text-xl font-semibold text-[color:var(--ryokufuu-800)]">
+                  {value.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-[color:var(--ryokufuu-700)]">
+                  {value.description}
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/lp/page.tsx
+++ b/app/lp/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+import { AutomationFlow } from "./_components/automation-flow";
+import { CtaFooter } from "./_components/cta-footer";
+import { ExperiencePreview } from "./_components/experience-preview";
+import { FaqSection } from "./_components/faq-section";
+import { HeroSection } from "./_components/hero-section";
+import { PricingSection } from "./_components/pricing-section";
+import { ValueHighlights } from "./_components/value-highlights";
+
+const highlights = [
+  {
+    caption: "Smartphone",
+    title: "ホーム画面追加でフルスクリーン体験",
+    description:
+      "PWAとしてホーム画面に追加するだけで、URLバーのないアプリ表示に。タブのスワイプやスクロール挙動も再現しています。",
+  },
+  {
+    caption: "Desktop",
+    title: "2ペイン構成で操作と表示を同時確認",
+    description:
+      "PCでは会話リストとトーク画面の2ペインレイアウトに自動調整。オンライン研修や画面共有でも使いやすい設計です。",
+  },
+  {
+    caption: "Security",
+    title: "契約停止時はローカルデータをロック",
+    description:
+      "契約期間中のみダミーデータにアクセス可能。将来的な手動バックアップ処理時以外は通信を行わず安全性を確保します。",
+  },
+  {
+    caption: "TXT Import",
+    title: "会話履歴のTXTを取り込んで自動生成",
+    description:
+      "実LINEからエクスポートしたTXTをアップロードすると、友だち・トーク・VOOM・ニュースを自動生成。編集も自由自在です。",
+  },
+];
+
+export const metadata: Metadata = {
+  title: "LINE風PWAダミー環境 LP | PWA LINE Studio",
+  description:
+    "LINEそっくりのPWAダミー環境をLP限定で提供。スマホ・PCに対応し、TXTアップロードでトークを自動生成。7日間無料トライアルあり。",
+  alternates: {
+    canonical: "/lp",
+  },
+  openGraph: {
+    title: "LP限定のLINE風PWAダミー環境",
+    description:
+      "友だち・トーク・VOOM・ニュース・ウォレットを再現したPWAを完全オフラインで利用。研修や検証を安全に行えます。",
+    url: "https://lp.example.com",
+  },
+};
+
+export default function LandingPage() {
+  return (
+    <main className="flex flex-col gap-0 bg-[color:var(--background)]">
+      <HeroSection />
+      <ValueHighlights values={highlights} />
+      <ExperiencePreview />
+      <AutomationFlow />
+      <PricingSection />
+      <FaqSection />
+      <CtaFooter />
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,275 @@
+import Link from "next/link";
+
+const features = [
+  {
+    title: "完全オフラインの検証環境",
+    description:
+      "実LINEと見た目・操作感がそっくりなPWAをスマホにインストール。通信を遮断してもダミーの友だち管理やトークの閲覧・編集が行えます。",
+  },
+  {
+    title: "TXTから自動生成",
+    description:
+      "実LINEからエクスポートした会話履歴 (TXT) を読み込むだけで、トーク・友だち・VOOMを再現。研修用シナリオを素早く準備できます。",
+  },
+  {
+    title: "安全なバックアップ運用",
+    description:
+      "送受信は行わず、将来的な手動バックアップ処理時のみ通信が発生。契約停止時にはローカルデータも閲覧不可になります。",
+  },
+];
+
+const scenarios = [
+  {
+    name: "研修・ロールプレイ",
+    detail:
+      "新人研修やカスタマーサポートのロールプレイで、現場同様のUIを活用しながら指導ができます。",
+  },
+  {
+    name: "情報共有のシミュレーション",
+    detail: "通知やニュースタブを使った配信計画をオフラインで検証。誤配信リスクを抑えられます。",
+  },
+  {
+    name: "デモンストレーション",
+    detail:
+      "顧客向け提案資料として、インストール済みのPWAを提示。アプリ風の表示でUXをそのまま伝えられます。",
+  },
+];
+
+const steps = [
+  {
+    step: "Step 1",
+    title: "TXTをアップロード",
+    description:
+      "実LINEから出力したトーク履歴 (TXT) をアップロードするとダミーデータが生成されます。",
+  },
+  {
+    step: "Step 2",
+    title: "PWAを端末に追加",
+    description:
+      "PWAとしてホーム画面に追加することで、URLバーのないアプリライクな画面で利用できます。",
+  },
+  {
+    step: "Step 3",
+    title: "シナリオを編集・共有",
+    description:
+      "友だちやトークを自由に編集し、研修シナリオを保存。必要に応じてバックアップを取得します。",
+  },
+];
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center px-6 py-24">
-      <div className="max-w-xl space-y-4 text-center">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[color:rgba(23,23,23,0.7)] dark:text-[color:rgba(237,237,237,0.7)]">
-          coming soon
-        </p>
-        <h1 className="text-4xl font-semibold tracking-tight text-[color:var(--foreground)] sm:text-5xl">
-          Dummy LINE UI Starter
-        </h1>
-        <p className="text-base leading-relaxed text-[color:rgba(23,23,23,0.75)] dark:text-[color:rgba(237,237,237,0.75)]">
-          Kickstart progressive LINE experiences with a modern Next.js, Tailwind CSS, and PWA-ready
-          foundation.
-        </p>
-      </div>
+    <main className="flex flex-col gap-24 pb-24">
+      <header className="relative isolate overflow-hidden bg-gradient-to-br from-[color:var(--ryokufuu-100)] via-white to-[color:var(--ryokufuu-200)] px-6 pb-24 pt-20 sm:rounded-b-[4rem] sm:px-10 sm:pt-28">
+        <div className="mx-auto flex max-w-5xl flex-col items-center gap-12 text-center sm:gap-16">
+          <p className="rounded-full bg-[color:var(--surface-soft)] px-4 py-1 text-sm font-semibold text-[color:var(--ryokufuu-700)]">
+            PWA LINE Studio
+          </p>
+          <div className="space-y-6">
+            <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-6xl">
+              見た目も操作感もLINEそっくり。\n完全オフラインで使える研修用PWA。
+            </h1>
+            <p className="text-base leading-relaxed text-[color:var(--ryokufuu-800)] sm:text-lg">
+              スマホにインストールできる仮想チャット環境で、友だち追加やトーク編集を安全に実演。\nVOOM・ニュース・ウォレットタブも搭載し、現場さながらのシミュレーションが可能です。
+            </p>
+          </div>
+          <div className="flex flex-col items-center gap-4 sm:flex-row">
+            <Link
+              href="https://example.com/signup"
+              className="rounded-full bg-[color:var(--ryokufuu-600)] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[rgba(47,143,116,0.35)] transition hover:bg-[color:var(--ryokufuu-700)]"
+            >
+              7日間無料トライアルを開始
+            </Link>
+            <Link
+              href="#features"
+              className="text-base font-semibold text-[color:var(--ryokufuu-700)] underline-offset-4 transition hover:text-[color:var(--ryokufuu-900)] hover:underline"
+            >
+              機能を見る
+            </Link>
+          </div>
+          <div className="grid w-full gap-4 rounded-3xl bg-white/70 p-6 shadow-xl shadow-[rgba(23,53,40,0.08)] ring-1 ring-[color:var(--surface-strong)] backdrop-blur md:grid-cols-3">
+            {features.map((feature) => (
+              <div key={feature.title} className="space-y-2 text-left">
+                <h3 className="text-lg font-semibold text-[color:var(--ryokufuu-700)]">
+                  {feature.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-[color:var(--ryokufuu-800)]">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <section id="features" className="px-6 sm:px-10">
+        <div className="mx-auto grid max-w-5xl gap-16 lg:grid-cols-[1.1fr,0.9fr]">
+          <div className="space-y-6">
+            <h2 className="text-3xl font-semibold text-[color:var(--ryokufuu-800)] sm:text-4xl">
+              LINE風タブをまるごと再現
+            </h2>
+            <p className="text-base leading-relaxed text-[color:var(--ryokufuu-800)]">
+              トーク、友だち、VOOM、ニュース、ウォレットの各タブを搭載。スライド式のタブバーやトークルームの演出も再現し、学習者は実アプリの操作感で研修に臨めます。
+            </p>
+            <div className="grid gap-4 rounded-2xl bg-white/70 p-6 shadow-lg shadow-[rgba(23,53,40,0.06)] ring-1 ring-[color:var(--surface-soft)]">
+              {scenarios.map((scenario) => (
+                <div key={scenario.name} className="rounded-xl bg-[color:var(--surface-soft)] p-5">
+                  <h3 className="text-lg font-semibold text-[color:var(--ryokufuu-700)]">
+                    {scenario.name}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-[color:var(--ryokufuu-800)]">
+                    {scenario.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center justify-center">
+            <div className="relative isolate w-full max-w-sm rounded-[2.5rem] bg-gradient-to-b from-white via-[color:var(--ryokufuu-100)] to-[color:var(--ryokufuu-200)] p-6 shadow-2xl">
+              <div className="absolute inset-x-10 top-4 h-1 rounded-full bg-[color:var(--ryokufuu-300)]" />
+              <div className="mt-8 space-y-4 rounded-2xl bg-white/80 p-5 text-left shadow-lg">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--ryokufuu-500)]">
+                    トーク
+                  </p>
+                  <p className="mt-2 text-sm text-[color:var(--ryokufuu-800)]">
+                    会話をオフラインで管理。吹き出しをタップするとテキスト編集や削除が可能です。
+                  </p>
+                </div>
+                <div className="rounded-xl bg-[color:var(--ryokufuu-100)] p-4">
+                  <p className="text-xs font-semibold text-[color:var(--ryokufuu-700)]">
+                    友だち一覧
+                  </p>
+                  <p className="mt-1 text-xs text-[color:var(--ryokufuu-800)]">
+                    タグ分け・ノートの追加で研修シナリオを整理できます。
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--ryokufuu-500)]">
+                    ニュース / VOOM
+                  </p>
+                  <p className="mt-2 text-sm text-[color:var(--ryokufuu-800)]">
+                    配信イメージを事前にチェック。テンプレートの差し替えで複数の案を比較できます。
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-6 sm:px-10">
+        <div className="mx-auto flex max-w-5xl flex-col gap-12 rounded-3xl bg-gradient-to-r from-[color:var(--ryokufuu-900)] via-[color:var(--ryokufuu-700)] to-[color:var(--ryokufuu-500)] px-8 py-12 text-white shadow-2xl sm:px-12">
+          <div className="space-y-4">
+            <h2 className="text-3xl font-semibold text-balance sm:text-4xl">
+              セキュリティと運用に配慮した仕組み
+            </h2>
+            <p className="text-base leading-relaxed text-white/90">
+              アプリ内での送受信は行わず、将来的な手動バックアップのみ通信を許可。契約停止時にはローカルデータも閲覧不可になる仕組みで、機密情報の持ち出しリスクを抑えます。
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {steps.map((step) => (
+              <div key={step.title} className="rounded-2xl bg-white/15 p-6 backdrop-blur">
+                <p className="text-xs font-semibold uppercase tracking-[0.25em] text-white/70">
+                  {step.step}
+                </p>
+                <h3 className="mt-2 text-lg font-semibold">{step.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-white/80">{step.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="pricing" className="px-6 sm:px-10">
+        <div className="mx-auto max-w-5xl space-y-10 text-center">
+          <div className="space-y-4">
+            <h2 className="text-3xl font-semibold text-[color:var(--ryokufuu-800)] sm:text-4xl">
+              シンプルな料金プラン
+            </h2>
+            <p className="text-base text-[color:var(--ryokufuu-700)]">
+              月額480円で全機能を利用可能。7日間の無料トライアル期間中に操作感をお試しいただけます。
+            </p>
+          </div>
+          <div className="mx-auto grid max-w-4xl gap-6 rounded-3xl bg-white/80 p-10 shadow-xl shadow-[rgba(23,53,40,0.08)] ring-1 ring-[color:var(--surface-strong)] md:grid-cols-2">
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-[color:var(--ryokufuu-500)]">
+                Standard
+              </p>
+              <p className="text-5xl font-semibold text-[color:var(--ryokufuu-800)]">
+                480<span className="text-2xl font-medium">円/月</span>
+              </p>
+              <p className="text-sm text-[color:var(--ryokufuu-700)]">
+                端末台数無制限 / 契約中データ保護
+              </p>
+            </div>
+            <ul className="space-y-3 text-left text-sm text-[color:var(--ryokufuu-800)]">
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-[color:var(--ryokufuu-500)]" />
+                完全オフラインで友だち・トーク・VOOMデータを編集
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-[color:var(--ryokufuu-500)]" />
+                TXTアップロードでの自動シナリオ生成
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-[color:var(--ryokufuu-500)]" />
+                将来的な手動バックアップAPI (通信時のみ接続)
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-[color:var(--ryokufuu-500)]" />
+                契約停止時の自動ロックで情報漏えいリスクを抑制
+              </li>
+            </ul>
+          </div>
+          <Link
+            href="https://example.com/signup"
+            className="inline-flex items-center justify-center rounded-full bg-[color:var(--ryokufuu-600)] px-10 py-3 text-base font-semibold text-white shadow-lg shadow-[rgba(47,143,116,0.35)] transition hover:bg-[color:var(--ryokufuu-700)]"
+          >
+            申し込みページへ進む
+          </Link>
+        </div>
+      </section>
+
+      <section className="px-6 sm:px-10">
+        <div className="mx-auto max-w-5xl space-y-8 rounded-3xl bg-white/80 p-10 shadow-xl shadow-[rgba(23,53,40,0.08)] ring-1 ring-[color:var(--surface-soft)]">
+          <div className="text-center">
+            <h2 className="text-3xl font-semibold text-[color:var(--ryokufuu-800)]">
+              よくある質問
+            </h2>
+            <p className="mt-2 text-sm text-[color:var(--ryokufuu-700)]">
+              導入に関するご不明点はサポートチームまでお気軽にお問い合わせください。
+            </p>
+          </div>
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-semibold text-[color:var(--ryokufuu-700)]">
+                Q. 実際のLINEアカウントと連携しますか？
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-[color:var(--ryokufuu-800)]">
+                いいえ。アプリ内での送受信は行わず、すべてダミーデータで構成されます。端末ローカルで完結するため、情報漏えいの心配がありません。
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-[color:var(--ryokufuu-700)]">
+                Q. どの端末で利用できますか？
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-[color:var(--ryokufuu-800)]">
+                最新のモバイルブラウザ (Safari / Chrome)
+                とデスクトップブラウザに対応。PWAとしてインストールすればURLバーのないアプリ風UIになります。
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-[color:var(--ryokufuu-700)]">
+                Q. バックアップはどのように取得しますか？
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-[color:var(--ryokufuu-800)]">
+                管理者が実行する手動バックアップ処理時のみ通信を有効化します。オフライン状態では端末内で安全にデータが保持されます。
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
     </main>
   );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const LP_SUBDOMAIN = process.env.LP_SUBDOMAIN ?? "lp";
+
+function isLpSubdomain(hostname: string) {
+  const [hostWithoutPort] = hostname.split(":");
+  if (!hostWithoutPort) {
+    return false;
+  }
+
+  if (hostWithoutPort === `${LP_SUBDOMAIN}.localhost`) {
+    return true;
+  }
+
+  if (hostWithoutPort.endsWith(`.${LP_SUBDOMAIN}.localhost`)) {
+    return true;
+  }
+
+  const segments = hostWithoutPort.split(".");
+  if (segments.length <= 2) {
+    return segments[0] === LP_SUBDOMAIN;
+  }
+
+  return segments[0] === LP_SUBDOMAIN;
+}
+
+export function middleware(request: NextRequest) {
+  const host = request.headers.get("host");
+  if (!host) {
+    return NextResponse.next();
+  }
+
+  if (isLpSubdomain(host)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/lp";
+    return NextResponse.rewrite(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/|api/|_static/|.*\\..*).*)"],
+};


### PR DESCRIPTION
## Summary
- add middleware to rewrite lp subdomain requests to the marketing landing page
- build a green ryokufuu-themed LP with modular components that scale from smartphone to desktop
- refresh the default domain homepage copy, layout, and styling variables to match the new product story

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e26c96f88325a39d2cc2cd6055b5